### PR TITLE
Update Podspec and Readme to match Package swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 ## Requirements
 
 - Swift 5.0
-- iOS 9
+- iOS 11
 - macOS 10.12
 - tvOS 10.0
 - watchOS 6.0
@@ -45,7 +45,7 @@ pod 'dotLottieLoader'
 ### Swift Package Manager
 
 ```swift
-.package(url: "https://github.com/dotlottie/dotLottieLoader-ios.git", from: "0.1.4")
+.package(url: "https://github.com/dotlottie/dotLottieLoader-ios.git", from: "0.1.8")
 ```
 
 ## Using dotLottie

--- a/dotLottieLoader.podspec
+++ b/dotLottieLoader.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'dotLottieLoader'
-  s.version          = '0.1.4'
+  s.version          = '0.1.8'
   s.summary          = 'An iOS library to natively load .lottie files https://dotlottie.io/'
 
   s.description      = <<-DESC
@@ -29,5 +29,5 @@ dotLottieLoader is an open-source file format that aggregates one or more Lottie
 
   s.source_files = 'Sources/**/*'
 
-  s.dependency 'Zip', '~> 1.1'
+  s.dependency 'Zip', '>= 2.1.2'
 end


### PR DESCRIPTION
## Overview
The rule
```s.dependency 'Zip', '>= 2.1.2'```  
matched with
```.package(name: "Zip", url: "https://github.com/LottieFiles/Zip.git", from: "2.1.2")```


## Podspec check
<img width="500" src="https://user-images.githubusercontent.com/103911733/198913396-cf0bff95-57cc-4527-a36b-a790ae6d9816.png">

## Next steps (requires access)
`pod trunk push dotLottieLoader.podspec`